### PR TITLE
Fix error in `get_full_ts` when a series is empty.

### DIFF
--- a/src/zen_temple/repositories/solution_repository.py
+++ b/src/zen_temple/repositories/solution_repository.py
@@ -77,6 +77,9 @@ class SolutionRepository:
             year = 0
 
         full_ts = results.get_full_ts(component, scenario_name=scenario, year=year)
+        if full_ts.shape[0] == 0:
+            return DataResult(data_csv="", unit=unit)
+
         full_ts = full_ts[~full_ts.index.duplicated(keep="first")]
         full_ts = full_ts.loc[~(full_ts == 0).all(axis=1)]
 


### PR DESCRIPTION
If there were no data to be filtered an internal server error occurred. I fixed this by returning an empty result early when there is no data to be filtered.