### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## Changelog
+
+## 0.4.0.dev1 (2025-03-12)
+
+- Fix error in `get_full_ts` when there is no data.
+- Update ZEN Explorer to v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zen_temple"
-version = "0.3.2"
+version = "0.4.0.dev1"
 authors = [
   { name="Vinzenz Muser", email="muserv@ethz.ch" },
 ]

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+# This script bumps the version of the project by incrementing the patch version.
+# It also updates the version in the pyproject.toml file.
+
+# Either read the current version from the pyproject.toml file or get it as an argument
+if [ $# -eq 0 ]; then
+    old_version=$(grep -oP 'version = "\K(.*)(?=")' pyproject.toml)
+    version=$(echo $old_version | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+    echo "Bumping version from $old_version to $version"
+else
+    version=$1
+    echo "Bumping version to $version"
+fi
+
+# Update the version in the pyproject.toml file
+sed -i "s/version = \".*\"/version = \"$version\"/" pyproject.toml
+
+# Add new heading to the CHANGELOG.md file
+
+# Get the current date
+date=$(date +"%Y-%m-%d")
+
+# Create the new heading
+new_heading="## $version ($date)"
+
+# Insert the new heading on line 3 of the CHANGELOG.md file
+sed -i "3i$new_heading\n\n- Summarize your changes ...\n" CHANGELOG.md

--- a/src/zen_temple/repositories/solution_repository.py
+++ b/src/zen_temple/repositories/solution_repository.py
@@ -81,7 +81,7 @@ class SolutionRepository:
             return DataResult(data_csv="", unit=unit)
 
         full_ts = full_ts[~full_ts.index.duplicated(keep="first")]
-        full_ts = full_ts.loc[~(full_ts == 0).all(axis=1)]
+        full_ts = full_ts.loc[(full_ts != 0).any(axis=1)]
 
         if rolling_average_window_size > 1:
             full_ts = full_ts.rolling(rolling_average_window_size, axis=1).mean()
@@ -110,7 +110,7 @@ class SolutionRepository:
             raise HTTPException(status_code=404, detail=f"{component} not found!")
 
         if type(total) is not pd.Series:
-            total = total.loc[~(total == 0).all(axis=1)]  # type: ignore
+            total = total.loc[(total != 0).any(axis=1)]
 
         return DataResult(data_csv=str(total.to_csv(lineterminator="\n")), unit=unit)
 
@@ -177,7 +177,7 @@ class SolutionRepository:
             )
 
             if type(series) is not pd.Series and key != demand_name:
-                balances[key] = series.loc[~(series == 0).all(axis=1)]  # type: ignore
+                balances[key] = series.loc[(series != 0).any(axis=1)]
 
             if rolling_average_window_size > 1:
                 current_col = balances[key]


### PR DESCRIPTION
Bump versions, add a changelog and remove a deprecated warning.

This rewrite is sound because `not forall x . f(x) == 0` implies `exists x . f(x) != 0`.