### PR TITLE
Hide results that are numerically insignificant.

### DIFF
--- a/src/zen_temple/config.py
+++ b/src/zen_temple/config.py
@@ -7,10 +7,9 @@ load_dotenv()
 
 class Config:
     def __init__(self) -> None:
-        self.SOLUTION_FOLDER: str = os.getenv("SOLUTION_FOLDER")  # type: ignore
+        self.SOLUTION_FOLDER: str = os.getenv("SOLUTION_FOLDER", "./outputs")  # type: ignore
 
-        if self.SOLUTION_FOLDER is None:
-            self.SOLUTION_FOLDER = "./outputs"
+        self.EPS = os.getenv("EPS", 1e-6)
 
         self.check()
 

--- a/src/zen_temple/repositories/solution_repository.py
+++ b/src/zen_temple/repositories/solution_repository.py
@@ -81,7 +81,7 @@ class SolutionRepository:
             return DataResult(data_csv="", unit=unit)
 
         full_ts = full_ts[~full_ts.index.duplicated(keep="first")]
-        full_ts = full_ts.loc[(full_ts != 0).any(axis=1)]
+        full_ts = full_ts.loc[(abs(full_ts) > config.EPS * max(full_ts)).any(axis=1)]
 
         if rolling_average_window_size > 1:
             full_ts = full_ts.rolling(rolling_average_window_size, axis=1).mean()
@@ -110,7 +110,7 @@ class SolutionRepository:
             raise HTTPException(status_code=404, detail=f"{component} not found!")
 
         if type(total) is not pd.Series:
-            total = total.loc[(total != 0).any(axis=1)]
+            total = total.loc[(abs(total) > config.EPS * max(total)).any(axis=1)]
 
         return DataResult(data_csv=str(total.to_csv(lineterminator="\n")), unit=unit)
 
@@ -177,7 +177,7 @@ class SolutionRepository:
             )
 
             if type(series) is not pd.Series and key != demand_name:
-                balances[key] = series.loc[(series != 0).any(axis=1)]
+                balances[key] = series.loc[(abs(series) > config.EPS * max(series)).any(axis=1)]
 
             if rolling_average_window_size > 1:
                 current_col = balances[key]


### PR DESCRIPTION
Sometimes there are rows that have values that are close but not equal to zero. This PR removes all these columns from the result returned by the server.

This plot for example only has significant values for `pumped_hydro`
![image](https://github.com/user-attachments/assets/c6ab3342-985a-42cc-8d41-94ede285e768)

With this PR this plot becomes:
![image](https://github.com/user-attachments/assets/f4a2173e-f17f-459d-8eba-0741b72ae3a3)


